### PR TITLE
feat: use latest nonce

### DIFF
--- a/src/create-escrow.ts
+++ b/src/create-escrow.ts
@@ -121,6 +121,7 @@ export async function createEscrow(
   );
 
   console.log('Creating escrow...');
+  const latestNonce = await signer.getNonce('latest');
   const escrowClient = await EscrowClient.build(signer);
   const escrowAddress = await escrowClient.createFundAndSetupEscrow(
     fundTokenAddress,
@@ -135,6 +136,9 @@ export async function createEscrow(
       recordingOracleFee: BigInt(recordingOracleFee),
       reputationOracle: reputationOracleAddress,
       reputationOracleFee: BigInt(reputationOracleFee),
+    },
+    {
+      nonce: latestNonce,
     },
   );
 


### PR DESCRIPTION
## Issue tracking
Freestyle

## Context behind the change
In case tx from GA is stuck on mempool, we might want to cancel current action and retry it. In order to correctly process in such case - always use latest nonce for create escrow tx.

## How has this been tested?
We have the same approach in some other places, so just make sure linter is ✅ 

## Release plan
Merge, re-tag v2
