### PR TITLE
Add timeout to GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ This is a **composite GitHub Action** that can be used in your workflows to laun
     WEB3_PRIVATE_KEY: ${{ secrets.WEB3_PRIVATE_KEY }}
     # Webhook url of Slack channel where to send notifications. Optional
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    # Optional transaction wait timeout in milliseconds. Defaults to 120000
+    TX_WAIT_TIMEOUT_MS: "120000"
+    # Optional transaction confirmations to wait for. Defaults to 1
+    TX_CONFIRMATIONS: "1"
 ```
 
 Provide either:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: "Create Escrow"
-description: "Launch a campaign escrow with provided parameters"
-author: "Hu-Fi"
+name: 'Create Escrow'
+description: 'Launch a campaign escrow with provided parameters'
+author: 'Hu-Fi'
 inputs:
   exchange_name: { required: true }
   symbol: { required: true }
@@ -17,11 +17,11 @@ inputs:
 
 outputs:
   escrow_address:
-    description: "The address of the created escrow contract"
+    description: 'The address of the created escrow contract'
     value: ${{ steps.launch.outputs.escrow_address }}
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Prepare action configuration
       id: prepare_config
@@ -39,7 +39,7 @@ runs:
         node-version: ${{ steps.prepare_config.outputs.node_version }}
         # Since it's composite action and paths resolved in a different way
         # we have to cache manually
-        cache: ""
+        cache: ''
 
     - name: Install Corepack
       shell: bash
@@ -77,6 +77,6 @@ runs:
         RECORDING_ORACLE_ADDRESS: ${{ inputs.recording_oracle_address }}
         REPUTATION_ORACLE_ADDRESS: ${{ inputs.reputation_oracle_address }}
       run: |
-        timeout 5m yarn launch-campaign
+        yarn launch-campaign
         ESCROW_ADDRESS=$(<escrow_address.out)
         echo "escrow_address=$ESCROW_ADDRESS" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,6 @@ runs:
         RECORDING_ORACLE_ADDRESS: ${{ inputs.recording_oracle_address }}
         REPUTATION_ORACLE_ADDRESS: ${{ inputs.reputation_oracle_address }}
       run: |
-        yarn launch-campaign
+        timeout 5m yarn launch-campaign
         ESCROW_ADDRESS=$(<escrow_address.out)
         echo "escrow_address=$ESCROW_ADDRESS" >> "$GITHUB_OUTPUT"

--- a/src/create-escrow.ts
+++ b/src/create-escrow.ts
@@ -9,11 +9,10 @@ import { ethers, type InterfaceAbi } from 'ethers';
 
 import { ERC20_ABI, HMT_TOKEN_DECIMALS } from './constants';
 import { type CampaignManifest } from './create-manifest';
+import launcherConfig from './env-config';
 import { getTokenAddress, type CustomSigner } from './utils';
 
 const MIN_STAKED_AMOUNT_HMT = ethers.parseEther('0.001');
-const TX_WAIT_TIMEOUT_MS = 2 * 60_000;
-const TX_CONFIRMATIONS = 1;
 
 export async function createEscrow(
   signer: CustomSigner,
@@ -28,8 +27,8 @@ export async function createEscrow(
   },
 ): Promise<string> {
   const txOptions: TransactionOverrides = {
-    confirmations: TX_CONFIRMATIONS,
-    timeoutMs: TX_WAIT_TIMEOUT_MS,
+    confirmations: launcherConfig.transaction.confirmations,
+    timeoutMs: launcherConfig.transaction.waitTimeoutMs,
   };
 
   console.log('Checking staking info...');
@@ -98,7 +97,10 @@ export async function createEscrow(
       allowanceSpender,
       fundAmount,
     );
-    await approveAllowanceTx.wait(TX_CONFIRMATIONS, TX_WAIT_TIMEOUT_MS);
+    await approveAllowanceTx.wait(
+      launcherConfig.transaction.confirmations,
+      launcherConfig.transaction.waitTimeoutMs,
+    );
   } else {
     console.log('Sufficient allowance to create escrow');
   }

--- a/src/create-escrow.ts
+++ b/src/create-escrow.ts
@@ -3,6 +3,7 @@ import {
   StakingClient,
   NETWORKS,
   ChainId,
+  type TransactionOverrides,
 } from '@human-protocol/sdk';
 import { ethers, type InterfaceAbi } from 'ethers';
 
@@ -11,6 +12,8 @@ import { type CampaignManifest } from './create-manifest';
 import { getTokenAddress, type CustomSigner } from './utils';
 
 const MIN_STAKED_AMOUNT_HMT = ethers.parseEther('0.001');
+const TX_WAIT_TIMEOUT_MS = 2 * 60_000;
+const TX_CONFIRMATIONS = 1;
 
 export async function createEscrow(
   signer: CustomSigner,
@@ -24,6 +27,11 @@ export async function createEscrow(
     reputationOracleAddress: string;
   },
 ): Promise<string> {
+  const txOptions: TransactionOverrides = {
+    confirmations: TX_CONFIRMATIONS,
+    timeoutMs: TX_WAIT_TIMEOUT_MS,
+  };
+
   console.log('Checking staking info...');
   const stakingClient = await StakingClient.build(signer);
   const { stakedAmount } = await stakingClient.getStakerInfo(signer.address);
@@ -31,8 +39,8 @@ export async function createEscrow(
     console.log(
       `Provided launcher hasn't staked. Staking ${ethers.formatEther(MIN_STAKED_AMOUNT_HMT)} HMT...`,
     );
-    await stakingClient.approveStake(MIN_STAKED_AMOUNT_HMT);
-    await stakingClient.stake(MIN_STAKED_AMOUNT_HMT);
+    await stakingClient.approveStake(MIN_STAKED_AMOUNT_HMT, txOptions);
+    await stakingClient.stake(MIN_STAKED_AMOUNT_HMT, txOptions);
   } else {
     console.log(
       `Stake eligible: ${ethers.formatUnits(stakedAmount, HMT_TOKEN_DECIMALS)}`,
@@ -90,7 +98,7 @@ export async function createEscrow(
       allowanceSpender,
       fundAmount,
     );
-    await approveAllowanceTx.wait();
+    await approveAllowanceTx.wait(TX_CONFIRMATIONS, TX_WAIT_TIMEOUT_MS);
   } else {
     console.log('Sufficient allowance to create escrow');
   }
@@ -110,6 +118,7 @@ export async function createEscrow(
       reputationOracle: reputationOracleAddress,
     },
     {
+      ...txOptions,
       nonce: latestNonce,
     },
   );

--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -6,6 +6,8 @@ if (process.env.GITHUB_ACTIONS !== 'true') {
 }
 
 const MIN_START_DELAY = 0;
+const DEFAULT_TX_WAIT_TIMEOUT_MS = 2 * 60_000;
+const DEFAULT_TX_CONFIRMATIONS = 1;
 
 const ISO_DATE_FORMAT = Joi.string().isoDate();
 
@@ -27,6 +29,8 @@ type EnvConfig = {
   EXCHANGE_ORACLE_ADDRESS: string;
   RECORDING_ORACLE_ADDRESS: string;
   REPUTATION_ORACLE_ADDRESS: string;
+  TX_WAIT_TIMEOUT_MS: number;
+  TX_CONFIRMATIONS: number;
 };
 
 const envConfigSchema = Joi.object({
@@ -50,6 +54,16 @@ const envConfigSchema = Joi.object({
   EXCHANGE_ORACLE_ADDRESS: evmAddressSchema,
   RECORDING_ORACLE_ADDRESS: evmAddressSchema,
   REPUTATION_ORACLE_ADDRESS: evmAddressSchema,
+  TX_WAIT_TIMEOUT_MS: Joi.number()
+    .integer()
+    .positive()
+    .optional()
+    .default(DEFAULT_TX_WAIT_TIMEOUT_MS),
+  TX_CONFIRMATIONS: Joi.number()
+    .integer()
+    .positive()
+    .optional()
+    .default(DEFAULT_TX_CONFIRMATIONS),
 }).options({
   presence: 'required',
   allowUnknown: true,
@@ -77,6 +91,10 @@ type LauncherConfig = {
   };
   notifications: {
     slackWebhookUrl?: string;
+  };
+  transaction: {
+    waitTimeoutMs: number;
+    confirmations: number;
   };
 };
 
@@ -131,6 +149,10 @@ function loadEnvConfig(): LauncherConfig {
       },
       notifications: {
         slackWebhookUrl: parsedEnvConfig.SLACK_WEBHOOK_URL,
+      },
+      transaction: {
+        waitTimeoutMs: parsedEnvConfig.TX_WAIT_TIMEOUT_MS,
+        confirmations: parsedEnvConfig.TX_CONFIRMATIONS,
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Issue tracking
[#901](https://github.com/Hu-Fi/hufi/issues/901)

## Context behind the change
Adds timeouts to the launcher process and transaction waits so the GitHub Action cannot hang indefinitely during gas estimation or confirmation.

If RPC/gas estimation fails, the workflow now fails explicitly instead of getting stuck.

## How has this been tested?
<!--
  You should always test your changes.

  Describe the steps you took to make sure your PR does what it's supposed to do.
  How we ensure that adjacent code/features are still working?
  Are there any performance implications?
-->

## Release plan
<!--
  If not you, but somebody else will be deploying this, what they need to know/do to succeed?

  Add any action items that need to be done for the release (any step, before/during/after),
  e.g. running a DB migration, leaving a note about release in Slack, adding new envs, etc.
-->
