### PR TITLE
add support for campaign start and end dates in action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,28 @@ This is a **composite GitHub Action** that can be used in your workflows to laun
 ```yaml
 - uses: Hu-Fi/campaign-launcher-action@v1
   with:
-    # Exchange name where you want campaign paticipants to trade
-    EXCHANGE_NAME: "mexc"
+    # Exchange name where you want campaign participants to trade
+    exchange_name: "mexc"
     # Trading pair symbol for exchange (in <base>/<quote> format)
-    SYMBOL: "HMT/USDT"
-    # Duration of the campaign in hours
-    DURATION: "24"
-    # Delay in seconds before the campaign starts (added to current time)
-    START_DELAY: "3600"
+    symbol: "HMT/USDT"
+    # Option 1: explicit campaign window in ISO 8601 format
+    start_date: "2026-05-27T12:00:00.000Z"
+    end_date: "2026-05-28T12:00:00.000Z"
+    # Option 2: derive the campaign window from now
+    # duration: "24"
+    # start_delay: "3600"
     # Daily trading volume target (in <quote> token)
-    DAILY_VOLUME_TARGET: "100000.0"
+    daily_volume_target: "100000.0"
     # The token to use for rewards (only HMT and USDT are supported atm)
-    REWARD_TOKEN: "HMT"
+    reward_token: "HMT"
     # Total rewards amount for the whole campaign duration
-    REWARD_AMOUNT: "1000"
+    reward_amount: "1000"
     # Address of Exchange Oracle that will handle campaign
-    EXCHANGE_ORACLE_ADDRESS: "0x..."
+    exchange_oracle_address: "0x..."
     # Address of Recording Oracle that will handle campaign
-    RECORDING_ORACLE_ADDRESS: "0x..."
+    recording_oracle_address: "0x..."
     # Address of Reputation Oracle that will handle campaign
-    REPUTATION_ORACLE_ADDRESS: "0x..."
+    reputation_oracle_address: "0x..."
   env:
     # JSON-RPC endpoint for the blockchain. Campaign will be launched on its chain
     WEB3_RPC_URL: ${{ secrets.WEB3_RPC_URL }}
@@ -41,6 +43,13 @@ This is a **composite GitHub Action** that can be used in your workflows to laun
     # Webhook url of Slack channel where to send notifications. Optional
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
+
+Provide either:
+
+- `start_date` and `end_date` as ISO 8601 timestamps, or
+- `duration` in hours with optional `start_delay` in seconds.
+
+If `start_date` and `end_date` are provided, they take precedence over derived timing.
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,10 @@ author: "Hu-Fi"
 inputs:
   exchange_name: { required: true }
   symbol: { required: true }
-  duration: { required: true }
-  start_delay: { required: true }
+  duration: { required: false }
+  start_delay: { required: false }
+  start_date: { required: false }
+  end_date: { required: false }
   daily_volume_target: { required: true }
   reward_token: { required: true }
   reward_amount: { required: true }
@@ -66,6 +68,8 @@ runs:
         SYMBOL: ${{ inputs.symbol }}
         DURATION: ${{ inputs.duration }}
         START_DELAY: ${{ inputs.start_delay }}
+        START_DATE: ${{ inputs.start_date }}
+        END_DATE: ${{ inputs.end_date }}
         DAILY_VOLUME_TARGET: ${{ inputs.daily_volume_target }}
         REWARD_TOKEN: ${{ inputs.reward_token }}
         REWARD_AMOUNT: ${{ inputs.reward_amount }}

--- a/examples/campaign-example.yml
+++ b/examples/campaign-example.yml
@@ -29,8 +29,12 @@ jobs:
         with:
           exchange_name: ${{ github.event.inputs.exchange_name || 'mexc' }}
           symbol: ${{ github.event.inputs.symbol || 'HMT/USDT' }}
-          duration: "24"
-          start_delay: "0"
+          #option 1
+          # duration: "24"
+          # start_delay: "0"
+          #option 2
+          start_date: "2026-05-22T06:00:00.000Z"
+          end_date: "2026-05-23T06:00:00.000Z"
           daily_volume_target: ${{ github.event.inputs.daily_volume_target || '100000' }}
           reward_token: "USDT"
           reward_amount: ${{ github.event.inputs.reward_amount || '10' }}

--- a/src/create-manifest.ts
+++ b/src/create-manifest.ts
@@ -33,22 +33,34 @@ const marketMakingInputSchema = Joi.object({
     .strict()
     .min(6)
     .max(100 * 24)
-    .required(),
+    .optional(),
   /**
    * Expected in seconds
    */
   startDelay: Joi.number().strict().min(0).default(0),
+  startDate: Joi.string().isoDate().optional(),
+  endDate: Joi.string().isoDate().optional(),
   dailyVolumeTarget: Joi.number().strict().greater(0).required(),
 }).options({ allowUnknown: true, stripUnknown: false });
 
 export async function createMarketMakingCampaignManifest(input: {
   exchangeName: string;
   tradingPair: string;
-  duration: number;
+  duration?: number;
   startDelay?: number;
+  startDate?: string;
+  endDate?: string;
   dailyVolumeTarget: number;
 }): Promise<{ manifest: CampaignManifest; manifestHash: string }> {
-  let validatedInput: Required<typeof input>;
+  let validatedInput: {
+    exchangeName: string;
+    tradingPair: string;
+    duration?: number;
+    startDelay: number;
+    startDate?: string;
+    endDate?: string;
+    dailyVolumeTarget: number;
+  };
   try {
     validatedInput = Joi.attempt(input, marketMakingInputSchema, {
       abortEarly: false,
@@ -69,11 +81,33 @@ export async function createMarketMakingCampaignManifest(input: {
     throw new Error('Failed to create market making manifest');
   }
 
-  const startDelayMs = validatedInput.startDelay * 1000;
-  const startDate = new Date(Date.now() + startDelayMs);
+  const hasExplicitDates =
+    Boolean(validatedInput.startDate) || Boolean(validatedInput.endDate);
 
-  const durationMs = validatedInput.duration * 60 * 60 * 1000;
-  const endDate = new Date(startDate.valueOf() + durationMs);
+  if (hasExplicitDates) {
+    if (!validatedInput.startDate || !validatedInput.endDate) {
+      throw new Error('Both startDate and endDate are required together');
+    }
+  } else if (validatedInput.duration === undefined) {
+    throw new Error(
+      'Duration is required when startDate and endDate are not set',
+    );
+  }
+
+  const startDate = hasExplicitDates
+    ? new Date(validatedInput.startDate as string)
+    : new Date(Date.now() + validatedInput.startDelay * 1000);
+
+  const endDate = hasExplicitDates
+    ? new Date(validatedInput.endDate as string)
+    : new Date(
+        startDate.valueOf() +
+          (validatedInput.duration as number) * 60 * 60 * 1000,
+      );
+
+  if (endDate.valueOf() <= startDate.valueOf()) {
+    throw new Error('End date must be later than start date');
+  }
 
   const manifest: MarketMakingCampaignManifest = {
     type: CampaignType.MARKET_MAKING,

--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -7,6 +7,8 @@ if (process.env.GITHUB_ACTIONS !== 'true') {
 
 const MIN_START_DELAY = 0;
 
+const ISO_DATE_FORMAT = Joi.string().isoDate();
+
 const evmAddressSchema = Joi.string().pattern(/^0x[0-9a-fA-F]{40}$/);
 
 type EnvConfig = {
@@ -15,8 +17,10 @@ type EnvConfig = {
   SLACK_WEBHOOK_URL?: string;
   EXCHANGE_NAME: string;
   SYMBOL: string;
-  DURATION: number;
-  START_DELAY: number;
+  DURATION?: number;
+  START_DELAY?: number;
+  START_DATE?: string;
+  END_DATE?: string;
   DAILY_VOLUME_TARGET: number;
   REWARD_TOKEN: string;
   REWARD_AMOUNT: string;
@@ -33,11 +37,13 @@ const envConfigSchema = Joi.object({
     .optional(),
   EXCHANGE_NAME: Joi.string().min(2),
   SYMBOL: Joi.string().min(2),
-  DURATION: Joi.number().positive(),
+  DURATION: Joi.number().positive().optional(),
   START_DELAY: Joi.number()
     .min(MIN_START_DELAY)
     .optional()
     .default(MIN_START_DELAY),
+  START_DATE: ISO_DATE_FORMAT.optional(),
+  END_DATE: ISO_DATE_FORMAT.optional(),
   DAILY_VOLUME_TARGET: Joi.number().positive(),
   REWARD_TOKEN: Joi.string().valid('usdt', 'hmt').insensitive(),
   REWARD_AMOUNT: Joi.string().pattern(/^\d+(\.\d{1,18})?$/),
@@ -58,8 +64,10 @@ type LauncherConfig = {
   campaign: {
     exchangeName: string;
     symbol: string;
-    duration: number;
-    startDelay: number;
+    duration?: number;
+    startDelay?: number;
+    startDate?: string;
+    endDate?: string;
     rewardToken: string;
     rewardAmount: string;
     exchangeOracleAddress: string;
@@ -82,6 +90,26 @@ function loadEnvConfig(): LauncherConfig {
       },
     );
 
+    const hasExplicitDates =
+      Boolean(parsedEnvConfig.START_DATE) || Boolean(parsedEnvConfig.END_DATE);
+
+    if (hasExplicitDates) {
+      if (!parsedEnvConfig.START_DATE || !parsedEnvConfig.END_DATE) {
+        throw new Error('START_DATE and END_DATE must be provided together');
+      }
+
+      if (
+        new Date(parsedEnvConfig.END_DATE).valueOf() <=
+        new Date(parsedEnvConfig.START_DATE).valueOf()
+      ) {
+        throw new Error('END_DATE must be later than START_DATE');
+      }
+    } else if (parsedEnvConfig.DURATION === undefined) {
+      throw new Error(
+        'Either START_DATE and END_DATE or DURATION must be provided',
+      );
+    }
+
     return {
       web3: {
         rpcUrl: parsedEnvConfig.WEB3_RPC_URL,
@@ -92,6 +120,8 @@ function loadEnvConfig(): LauncherConfig {
         symbol: parsedEnvConfig.SYMBOL,
         duration: parsedEnvConfig.DURATION,
         startDelay: parsedEnvConfig.START_DELAY,
+        startDate: parsedEnvConfig.START_DATE,
+        endDate: parsedEnvConfig.END_DATE,
         rewardToken: parsedEnvConfig.REWARD_TOKEN,
         rewardAmount: parsedEnvConfig.REWARD_AMOUNT,
         exchangeOracleAddress: parsedEnvConfig.EXCHANGE_ORACLE_ADDRESS,

--- a/src/launch-campaign.ts
+++ b/src/launch-campaign.ts
@@ -22,6 +22,8 @@ void (async () => {
         tradingPair: launcherConfig.campaign.symbol,
         duration: launcherConfig.campaign.duration,
         startDelay: launcherConfig.campaign.startDelay,
+        startDate: launcherConfig.campaign.startDate,
+        endDate: launcherConfig.campaign.endDate,
         dailyVolumeTarget: launcherConfig.campaign.dailyVolumeTarget,
       },
     );


### PR DESCRIPTION
## Issue tracking
NA

## Context behind the change
Add support for specifying campaign start and end times. The changes update input validation, environment configuration, documentation, and example workflows to reflect these new options.


## How has this been tested?
Needs to be released to be tested

## Release plan
NA
